### PR TITLE
Make Qt platform-plugin resolution fall back gracefully for local builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,17 @@ endif()
 
 find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets Xml)
 
+# Fallback plugin path for ensureQtPluginPathFallback() in main.cpp: the
+# plugins directory of the Qt used for this build, baked in as a fallback
+# for when qt.conf's "Plugins = plugins" (relative, for bundled deploys)
+# doesn't resolve to an existing folder, e.g. a plain local build.
+get_target_property(EMSTUDIO_QT_QMAKE_EXECUTABLE Qt5::qmake IMPORTED_LOCATION)
+execute_process(
+    COMMAND "${EMSTUDIO_QT_QMAKE_EXECUTABLE}" -query QT_INSTALL_PLUGINS
+    OUTPUT_VARIABLE EMSTUDIO_QT_PLUGINS_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 # -----------------------------------------------------------------------------
 # Versioning (как в .pro)
 # -----------------------------------------------------------------------------
@@ -215,6 +226,7 @@ target_compile_definitions(EMStudio PRIVATE
     EMSTUDIO_VERSION_STR="${EMSTUDIO_VERSION}"
     EMSTUDIO_MAJOR=${EMSTUDIO_MAJOR}
     EMSTUDIO_GIT_DATE_STR="${EMSTUDIO_GIT_DATE}"
+    EMSTUDIO_BUILD_QT_PLUGINS_PATH="${EMSTUDIO_QT_PLUGINS_DIR}"
 )
 
 target_link_libraries(EMStudio PRIVATE

--- a/EMStudio.pro
+++ b/EMStudio.pro
@@ -121,3 +121,10 @@ DEFINES += EMSTUDIO_MAJOR=$$EMSTUDIO_MAJOR
 
 EMSTUDIO_GIT_DATE = $$system(git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%S)
 DEFINES += EMSTUDIO_GIT_DATE_STR=\\\"$${EMSTUDIO_GIT_DATE}\\\"
+
+# Fallback plugin path for ensureQtPluginPathFallback() in main.cpp: the
+# plugins directory of the Qt used for this build, baked in as a fallback
+# for when qt.conf's "Plugins = plugins" (relative, for bundled deploys)
+# doesn't resolve to an existing folder, e.g. a plain local build.
+EMSTUDIO_QT_PLUGINS_DIR = $$[QT_INSTALL_PLUGINS]
+DEFINES += EMSTUDIO_BUILD_QT_PLUGINS_PATH=\\\"$${EMSTUDIO_QT_PLUGINS_DIR}\\\"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ make -j$(nproc)
 ./EMStudio
 ```
 
-If `./EMStudio` fails to start with a "Qt platform plugin" error, use the pre-built Linux bundle above instead, or see [issue #19](https://github.com/IHP-GmbH/EMStudio/issues/19) for a workaround.
+If `./EMStudio` still fails to start with a "Qt platform plugin" error, use the pre-built Linux bundle above instead. See [issue #19](https://github.com/IHP-GmbH/EMStudio/issues/19) for details.
 
 **Windows (MinGW, matching our CI build):**
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,6 +74,7 @@
 
 #include <QTimer>
 #include <QDebug>
+#include <QDir>
 #include <QPixmap>
 #include <QFileInfo>
 #include <QMessageBox>
@@ -88,9 +89,35 @@
 
 #if defined(Q_OS_WIN)
 #  include <windows.h>
+#elif defined(Q_OS_LINUX)
+#  include <unistd.h>
 #endif
 
 namespace {
+
+/*! Path of the running executable's own directory, determined without
+ *  relying on QCoreApplication (which isn't constructed yet). Needed because
+ *  QLibraryInfo only resolves qt.conf's paths relative to the executable
+ *  once an application instance exists - too late to fix up plugin loading,
+ *  which happens inside the QApplication constructor itself. */
+QString executableDirectory()
+{
+#if defined(Q_OS_WIN)
+    wchar_t buffer[MAX_PATH];
+    const DWORD len = GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+    if (len == 0 || len == MAX_PATH)
+        return QString();
+    return QFileInfo(QString::fromWCharArray(buffer, len)).absolutePath();
+#elif defined(Q_OS_LINUX)
+    char buffer[4096];
+    const ssize_t len = readlink("/proc/self/exe", buffer, sizeof(buffer) - 1);
+    if (len <= 0)
+        return QString();
+    return QFileInfo(QString::fromLocal8Bit(buffer, static_cast<int>(len))).absolutePath();
+#else
+    return QString();
+#endif
+}
 
 #if defined(Q_OS_WIN)
 /*! Prefer Per-Monitor V2 before QApplication so Qt High-DPI and the native
@@ -124,6 +151,45 @@ void normalizeApplicationFontForHighDpi()
     else
         normalized.setPointSize(9);
     QApplication::setFont(normalized);
+}
+
+/*! qt.conf ships a relative "Plugins = plugins" entry for bundled/deployed
+ *  builds (windeployqt, the CI Linux bundle), where that folder is placed
+ *  next to the executable. A plain local build has no such folder, so Qt
+ *  would resolve the platform plugin search path to a location that doesn't
+ *  exist and refuse to start ("Could not find the Qt platform plugin").
+ *  Detect that case and fall back to the plugin directory of the Qt this
+ *  binary was built against. Must run before QApplication is constructed,
+ *  since platform plugin loading happens inside its constructor - too late
+ *  to query QLibraryInfo, which only resolves qt.conf relative to the
+ *  executable once an application instance exists. */
+void ensureQtPluginPathFallback()
+{
+    if (qEnvironmentVariableIsSet("QT_PLUGIN_PATH")
+        || qEnvironmentVariableIsSet("QT_QPA_PLATFORM_PLUGIN_PATH")) {
+        return; // already configured explicitly, don't override
+    }
+
+    const QString exeDir = executableDirectory();
+    if (exeDir.isEmpty())
+        return; // couldn't determine reliably, leave Qt's own resolution alone
+
+    // Mirrors qt.conf's "[Paths] Plugins = plugins" - keep in sync if that changes.
+    if (QDir(exeDir + QLatin1String("/plugins")).exists())
+        return; // bundled/deployed layout is present, nothing to do
+
+#ifdef EMSTUDIO_BUILD_QT_PLUGINS_PATH
+    const QString fallback = QStringLiteral(EMSTUDIO_BUILD_QT_PLUGINS_PATH);
+    if (QDir(fallback).exists()) {
+        // QCoreApplication::addLibraryPath() is too late here: once qt.conf
+        // declares a Plugins entry, Qt's platform-plugin loader (which runs
+        // inside the QApplication constructor) resolves exclusively through
+        // qt.conf and ignores paths added beforehand. Environment variables
+        // are read directly by that loader, so they reliably take effect.
+        qputenv("QT_PLUGIN_PATH", fallback.toUtf8());
+        qputenv("QT_QPA_PLATFORM_PLUGIN_PATH", (fallback + QLatin1String("/platforms")).toUtf8());
+    }
+#endif
 }
 
 } // namespace
@@ -176,6 +242,8 @@ int main(int argc, char *argv[])
     QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
         Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
+
+    ensureQtPluginPathFallback();
 
     QApplication a(argc, argv);
     normalizeApplicationFontForHighDpi();


### PR DESCRIPTION
## Summary
- Fixes #19: a plain local build (`qmake && make && ./EMStudio`) aborted with `Could not find the Qt platform plugin "xcb" in ""`, because `qt.conf`'s relative `Plugins = plugins` entry only resolves for bundled/deployed layouts (windeployqt, the CI Linux bundle) that actually ship a `plugins/` folder next to the executable.
- Before `QApplication` is constructed, EMStudio now checks whether that folder exists next to the running executable. If it doesn't, it falls back to the plugin directory of the Qt installation the binary was built against (baked in at build time via `qmake`/`CMake`, mirroring how `EMSTUDIO_VERSION_STR` is already embedded), by setting `QT_PLUGIN_PATH`/`QT_QPA_PLATFORM_PLUGIN_PATH` — the environment variables Qt's plugin loader actually honors before `qt.conf` is otherwise resolved in this early-startup window.
- Nothing changes if a user already set `QT_PLUGIN_PATH`/`QT_QPA_PLATFORM_PLUGIN_PATH` themselves, or if a real bundled `plugins/` folder is present (packaged Windows/Linux builds are unaffected).
- Also trims the now-mostly-moot troubleshooting note in the README that was added as a stopgap for this issue.

## Test plan
- [x] Built with `qmake EMStudio.pro && make -j$(nproc)` on Ubuntu 24.04 with the original (broken) `qt.conf` still in place, no env var overrides: `./EMStudio` now starts normally instead of aborting.
- [x] Manually staged a `plugins/platforms` folder next to the binary (simulating the bundled/deployed layout) and confirmed the app still starts using that folder — no regression to the existing packaged-build behavior.